### PR TITLE
updating example docs to reflect latest three.js version

### DIFF
--- a/examples/README.markdown
+++ b/examples/README.markdown
@@ -14,6 +14,8 @@ One of the most convenient ways of using Cannon.js with [Three.js](https://githu
 mesh.useQuaternion = true;
 ```
 
+*Note:* On the latest version of Three.js (r59) useQuaternion is true by default.
+
 Then it gets really simple to copy over position+orientation data to the Three.js mesh:
 ```javascript
 rigidbody.position.copy(mesh.position);


### PR DESCRIPTION
Hi,

It was just something I discovered while updating the fps example to three.js r59: https://github.com/danielribeiro/cannon.js/tree/walking-cube

Note: I did more changes than that on the walking-cube branch, hence that is not a pull request yet.

Cheers,
- Daniel
