### PR TITLE
Added array access to vec3 and quat

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -59,6 +59,16 @@ CANNON.Quaternion.prototype.toString = function(){
 };
 
 /**
+ * @method toArray
+ * @memberof CANNON.Quaternion
+ * @brief Convert to an Array
+ * @return Array
+ */
+CANNON.Quaternion.prototype.toArray = function(){
+    return [this.x, this.y, this.z, this.w];
+};
+
+/**
  * @method setFromAxisAngle
  * @memberof CANNON.Quaternion
  * @brief Set the quaternion components given an axis and an angle.

--- a/src/math/Vec3.js
+++ b/src/math/Vec3.js
@@ -291,6 +291,16 @@ CANNON.Vec3.prototype.toString = function(){
 };
 
 /**
+ * @method toArray
+ * @memberof CANNON.Vec3
+ * @brief Converts to an array
+ * @return Array
+ */
+CANNON.Vec3.prototype.toArray = function(){
+    return [this.x, this.y, this.z];
+};
+
+/**
  * @method copy
  * @memberof CANNON.Vec3
  * @brief Copy the vector.


### PR DESCRIPTION
A minor change, mainly to make the above classes integrate nicer with glMatrix, e.g. mat4.translate(modelMatrix, modelMatrix, [rigidbody.position.x, rigidbody.position.y, rigidbody.position.x]) now becomes mat4.translate(modelMatrix, modelMatrix, rigidbody.position.toArray())
