### PR TITLE
fix Heightfield.getRectMinMax()

### DIFF
--- a/src/shapes/Heightfield.js
+++ b/src/shapes/Heightfield.js
@@ -175,8 +175,8 @@ Heightfield.prototype.getRectMinMax = function (iMinX, iMinY, iMaxX, iMaxY, resu
     // Get max and min of the data
     var data = this.data,
         max = this.minValue; // Set first value
-    for(var i = iMinX; i < iMaxX; i++){
-        for(var j = iMinY; j < iMaxY; j++){
+    for(var i = iMinX; i <= iMaxX; i++){
+        for(var j = iMinY; j <= iMaxY; j++){
             var height = data[i][j];
             if(height > max){
                 max = height;


### PR DESCRIPTION
this fix #180. iMaxX & iMaxY in Heightfield.getRectMinMax should be covered in the loop because they have been clamped in previous codes.