### PR TITLE
 NPM main entry point references source file

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "engine",
     "3d"
   ],
-  "main": "./build/cannon.js",
+  "main": "./src/Cannon.js",
   "engines": {
     "node": "*"
   },


### PR DESCRIPTION
The NPM main entry point of the package.json shouldn't reference a pre-build file, but instead the main source file. This fixes #199 

Tested with webpack, browserify and vanilla nodejs.