### PR TITLE
Polyfill performance.now on global object

### DIFF
--- a/src/world/World.js
+++ b/src/world/World.js
@@ -488,7 +488,12 @@ World.prototype.addContactMaterial = function(cmat) {
 
 // performance.now()
 if(typeof performance === 'undefined'){
-    performance = {};
+    if (typeof global !== undefined) {
+        global.performance = {};
+    }
+    if (typeof self !== 'undefined') {
+        self.performance = {};
+    }
 }
 if(!performance.now){
     var nowOffset = Date.now();


### PR DESCRIPTION
If cannon.js is included in a script that runs in strict mode, the polyfill of `performance` will throw an error because it's undeclared. You can see this by adding "use strict" to World.js or the built script and running the web workers example in Mobile Safari (iOS only supports `performance` in the main thread, not in a worker) or running the unit test (node doesn't support `performance` at all).

In browsers, the polyfill needs to be set on `self` in either worker or the main thread. In node, it needs to be set on `global`.