### PR TITLE
ConvexPolyhedron calculateWorldAABB() can return undefined values in max

### DIFF
--- a/src/shapes/ConvexPolyhedron.js
+++ b/src/shapes/ConvexPolyhedron.js
@@ -741,19 +741,25 @@ ConvexPolyhedron.prototype.calculateWorldAABB = function(pos,quat,min,max){
         var v = tempWorldVertex;
         if     (v.x < minx || minx===undefined){
             minx = v.x;
-        } else if(v.x > maxx || maxx===undefined){
+        } 
+        
+        if(v.x > maxx || maxx===undefined){
             maxx = v.x;
         }
 
         if     (v.y < miny || miny===undefined){
             miny = v.y;
-        } else if(v.y > maxy || maxy===undefined){
+        } 
+        
+        if(v.y > maxy || maxy===undefined){
             maxy = v.y;
         }
 
         if     (v.z < minz || minz===undefined){
             minz = v.z;
-        } else if(v.z > maxz || maxz===undefined){
+        }  
+        
+        if(v.z > maxz || maxz===undefined){
             maxz = v.z;
         }
     }

--- a/test/ConvexPolyhedron.js
+++ b/test/ConvexPolyhedron.js
@@ -26,6 +26,41 @@ module.exports = {
         test.done();
     },
 
+    calculateWorldAABBAlwaysDecreasingVertsNoUndefined: function(test) {
+        var vertices = [
+            new Vec3( 4, 4, 4),
+            new Vec3( 3, 3, 3),
+            new Vec3( 2, 2, 2),
+            new Vec3( 1, 1, 1),
+            new Vec3( 0, 0, 0),
+            new Vec3(-1,-1,-1),
+            new Vec3(-2,-2,-2),
+            new Vec3(-3,-3,-3)
+        ];
+    
+        var indices = [
+            [3,2,1,0],
+            [4,5,6,7],
+            [5,4,0,1],
+            [2,3,7,6],
+            [0,4,7,3],
+            [1,2,6,5],
+        ];
+
+        var poly = new ConvexPolyhedron(vertices, indices);
+        var min = new Vec3();
+        var max = new Vec3();
+        poly.calculateWorldAABB(new Vec3(0, 0, 0), new Quaternion(0, 0, 0, 1), min, max); 
+
+        test.notEqual(min.x, undefined);
+        test.notEqual(max.x, undefined);
+        test.notEqual(min.y, undefined);
+        test.notEqual(max.y, undefined);
+        test.notEqual(min.z, undefined);
+        test.notEqual(max.z, undefined);
+        test.done();
+    },
+
     clipFaceAgainstPlane : function(test){
         var h = createBoxHull();
 


### PR DESCRIPTION
I ran into a situation where the AABB of a Body I was creating had a `NaN` value in its calculated AABB. Turns out, if a ConvexPolyhedron has vertices where one or more components are always decreasing, the 
 AABB calculation had a bug where the `max[x|y|z]` values would remain undefined. This PR fixes the bug and adds a unit test for it.