### PR TITLE
Adding interpolated body properties to docs

### DIFF
--- a/docs/files/src_objects_Body.js.html
+++ b/docs/files/src_objects_Body.js.html
@@ -379,7 +379,16 @@ function Body(options){
      */
     this.initAngularVelocity = new Vec3();
 
+    /**
+     * @property interpolatedPosition
+     * @type {Vec3}
+     */
     this.interpolatedPosition = new Vec3();
+    
+    /**
+     * @property interpolatedQuaternion
+     * @type {Quaternion}
+     */
     this.interpolatedQuaternion = new Quaternion();
 
     /**


### PR DESCRIPTION
In the [yui docs](http://schteppe.github.io/cannon.js/docs/classes/Body.html), the body class is missing the _interpolatedPosition_ and _interpolatedQuaternion_ properties. Confused me quite a bit.

I assume the docs are generated and this change is all that's needed?

**Edit:** Now that I tried to use the properties, maybe they're not what I thought? Maybe they're meant to be undocumented? 😄
They're used in [canvas_interpolation.html](https://github.com/schteppe/cannon.js/blob/master/examples/canvas_interpolation.html) but don't work in my case...

**Edit2:** They don't even work in canvas_interpolation.html. Looks like an issue?
![](https://thumbs.gfycat.com/QuerulousBlankGreatwhiteshark-size_restricted.gif)
I can try to fix this but not sure it'll lead anywhere...