### PR TITLE
Fix several errors about trimesh

### DIFF
--- a/src/utils/Octree.js
+++ b/src/utils/Octree.js
@@ -220,14 +220,10 @@ OctreeNode.prototype.rayQuery = function(ray, treeTransform, result) {
  * @method removeEmptyNodes
  */
 OctreeNode.prototype.removeEmptyNodes = function() {
-    var queue = [this];
-    while (queue.length) {
-        var node = queue.pop();
-        for (var i = node.children.length - 1; i >= 0; i--) {
-            if(!node.children[i].data.length){
-                node.children.splice(i, 1);
-            }
+    for (var i = this.children.length - 1; i >= 0; i--) {
+        this.children[i].removeEmptyNodes();
+        if(!this.children[i].children.length && !this.children[i].data.length){
+            this.children.splice(i, 1);
         }
-        Array.prototype.push.apply(queue, node.children);
     }
 };

--- a/src/world/Narrowphase.js
+++ b/src/world/Narrowphase.js
@@ -607,6 +607,8 @@ Narrowphase.prototype.sphereTrimesh = function (
                     tmp.vsub(localSpherePos, r.ni);
                     r.ni.normalize();
                     r.ni.scale(sphereShape.radius, r.ri);
+                    r.ri.vadd(spherePos, r.ri);
+                    r.ri.vsub(sphereBody.position, r.ri);
 
                     Transform.pointToWorldFrame(trimeshPos, trimeshQuat, tmp, tmp);
                     tmp.vsub(trimeshBody.position, r.rj);
@@ -645,6 +647,8 @@ Narrowphase.prototype.sphereTrimesh = function (
             tmp.vsub(localSpherePos, r.ni);
             r.ni.normalize();
             r.ni.scale(sphereShape.radius, r.ri);
+            r.ri.vadd(spherePos, r.ri);
+            r.ri.vsub(sphereBody.position, r.ri);
 
             Transform.pointToWorldFrame(trimeshPos, trimeshQuat, tmp, tmp);
             tmp.vsub(trimeshBody.position, r.rj);


### PR DESCRIPTION
Threr are two errors in the trimesh system:

The error of collision of spheres with nonzero shapeOffset with trimesh was found.
The error is because one forget to add spherePos-sphereBody.position to r.ni in the edge and triangle cases.

Another error is the original method delete the children without triangle belongs to it, but it seems one forgot that, although there may be no triangle belongs to X, there may be triangles belong to X's children!
So I write a recursive algorithm for it to check if its children has any triangles in their descendents, then decide whether to delete them.