### PR TITLE
fix computeAABB orientation mult

### DIFF
--- a/src/collision/Ray.js
+++ b/src/collision/Ray.js
@@ -109,6 +109,7 @@ Ray.prototype.intersectWorld = function (world, options) {
     this.skipBackfaces = !!options.skipBackfaces;
     this.collisionFilterMask = typeof(options.collisionFilterMask) !== 'undefined' ? options.collisionFilterMask : -1;
     this.collisionFilterGroup = typeof(options.collisionFilterGroup) !== 'undefined' ? options.collisionFilterGroup : -1;
+    this.checkCollisionResponse = typeof(options.checkCollisionResponse) !== 'undefined' ? options.checkCollisionResponse : true;
     if(options.from){
         this.from.copy(options.from);
     }

--- a/src/objects/Body.js
+++ b/src/objects/Body.js
@@ -664,7 +664,7 @@ Body.prototype.computeAABB = function(){
         offset.vadd(this.position, offset);
 
         // Get shape world quaternion
-        shapeOrientations[i].mult(bodyQuat, orientation);
+        bodyQuat.mult(shapeOrientations[i], orientation);
 
         // Get shape AABB
         shape.calculateWorldAABB(offset, orientation, shapeAABB.lowerBound, shapeAABB.upperBound);


### PR DESCRIPTION
In Body.js computeAABB(): the order of quaternion multiplication is fixed.

Steps to reproduce computeAABB error with unmodified lib: 

1. create a body containing a cylinder shape.

2. when creating the cylinder shape set its localRotation to 45 degrees around z axis.

3. AABB of the body is not enlarged by tilt of the shape.
