### PR TITLE
docs: threejs.html update

### DIFF
--- a/examples/threejs.html
+++ b/examples/threejs.html
@@ -59,7 +59,7 @@
           mesh = new THREE.Mesh( geometry, material );
           scene.add( mesh );
 
-          renderer = new THREE.CanvasRenderer();
+          renderer = new THREE.WebGLRenderer();
           renderer.setSize( window.innerWidth, window.innerHeight );
 
           document.body.appendChild( renderer.domElement );


### PR DESCRIPTION
`THREE.CanvasRenderer()` no longer exists in current Three.js versions. Replacing with WebGLRenderer instead.